### PR TITLE
Xml file character encoding

### DIFF
--- a/Lib/src/net/sf/anathema/lib/xml/DocumentUtilities.java
+++ b/Lib/src/net/sf/anathema/lib/xml/DocumentUtilities.java
@@ -27,7 +27,7 @@ import org.xml.sax.EntityResolver;
 
 public class DocumentUtilities {
 
-  private static final String DEFAULT_ENCODING = "ISO-8859-1"; //$NON-NLS-1$
+  private static final String DEFAULT_ENCODING = "UTF-8"; //$NON-NLS-1$
 
   private DocumentUtilities() {
     // Nothing to do


### PR DESCRIPTION
Encoding was changed from LATIN1 to UTF-8 to support non english languages.
