### PR TITLE
Fixed Open Issue #9

### DIFF
--- a/macApplication.gradle
+++ b/macApplication.gradle
@@ -33,7 +33,7 @@ task copyContent(type: Copy) {
   into("${appDir}/Contents/") {
     from("Development_Distribution/Mac/")
     include 'Info.plist'
-    //filter(ReplaceTokens, tokens: ["version-major": "${version_major}", "version-minor": "${version_minor}", "version-revision": "${version_revision}"])
+    filter(ReplaceTokens, tokens: ["version-major": "${version_major}".toString(), "version-minor": "${version_minor}".toString(), "version-revision": "${version_revision}".toString()])
   }
   into("${appDir}/Contents/Resources") {
     from("Development_Distribution/Mac/")


### PR DESCRIPTION
Fixed Open [Issue #9](https://github.com/anathema/anathema/issues/9).

It looks like the ${version_number} shell variable substitutions were coming in as non-String types, and were causing class cast exceptions.

Changing them over to Strings fixes the issue, by either casting to a String, or calling toString().

So "${version_number}" becomes either (String)"${version_number}" or "${version_number}".toString().
