### PR TITLE
Fixed spelling error

### DIFF
--- a/Character_Generic_Impl/src/net/sf/anathema/character/generic/impl/CharacterUtilities.java
+++ b/Character_Generic_Impl/src/net/sf/anathema/character/generic/impl/CharacterUtilities.java
@@ -9,7 +9,7 @@ import net.sf.anathema.character.generic.traits.types.AttributeType;
 import net.sf.anathema.character.generic.traits.types.OtherTraitType;
 import net.sf.anathema.character.generic.type.ICharacterType;
 
-public class CharacterUtilties {
+public class CharacterUtilities {
 
   public static int getDodgeMdv(IGenericTraitCollection traitCollection, IEquipmentModifiers equipment) {
     int baseValue = getRoundDownDv(traitCollection, OtherTraitType.Willpower, AbilityType.Integrity,

--- a/Character_Generic_Impl/src/net/sf/anathema/character/generic/impl/social/AbstractSocialAttack.java
+++ b/Character_Generic_Impl/src/net/sf/anathema/character/generic/impl/social/AbstractSocialAttack.java
@@ -6,8 +6,8 @@ import net.sf.anathema.character.generic.social.ISocialCombatStats;
 import net.sf.anathema.character.generic.traits.ITraitType;
 import net.sf.anathema.character.generic.traits.types.AttributeType;
 
-import static net.sf.anathema.character.generic.impl.CharacterUtilties.getRoundUpDv;
-import static net.sf.anathema.character.generic.impl.CharacterUtilties.getTotalValue;
+import static net.sf.anathema.character.generic.impl.CharacterUtilities.getRoundUpDv;
+import static net.sf.anathema.character.generic.impl.CharacterUtilities.getTotalValue;
 import static net.sf.anathema.character.generic.traits.types.AttributeType.Charisma;
 import static net.sf.anathema.character.generic.traits.types.AttributeType.Manipulation;
 

--- a/Character_Generic_Impl/test/net/sf/anathema/character/generic/impl/CharacterUtilitiesTest.java
+++ b/Character_Generic_Impl/test/net/sf/anathema/character/generic/impl/CharacterUtilitiesTest.java
@@ -2,7 +2,7 @@ package net.sf.anathema.character.generic.impl;
 
 import net.sf.anathema.character.generic.dummy.DummyGenericTraitCollection;
 import net.sf.anathema.character.generic.equipment.IEquipmentModifiers;
-import net.sf.anathema.character.generic.impl.CharacterUtilties;
+import net.sf.anathema.character.generic.impl.CharacterUtilities;
 import net.sf.anathema.character.generic.traits.types.AbilityType;
 import net.sf.anathema.character.generic.traits.types.AttributeType;
 import net.sf.anathema.character.generic.traits.types.OtherTraitType;
@@ -22,7 +22,7 @@ public class CharacterUtilitiesTest {
     traitCollection.setValue(AbilityType.Integrity, 1);
     traitCollection.setValue(OtherTraitType.Essence, 1);
     traitCollection.setValue(OtherTraitType.Willpower, 4);
-    assertEquals(3, CharacterUtilties.getDodgeMdv(traitCollection, modifiers));
+    assertEquals(3, CharacterUtilities.getDodgeMdv(traitCollection, modifiers));
   }
 
   @Test
@@ -30,7 +30,7 @@ public class CharacterUtilitiesTest {
     traitCollection.setValue(AbilityType.Integrity, 1);
     traitCollection.setValue(OtherTraitType.Essence, 1);
     traitCollection.setValue(OtherTraitType.Willpower, 5);
-    assertEquals(3, CharacterUtilties.getDodgeMdv(traitCollection, modifiers));
+    assertEquals(3, CharacterUtilities.getDodgeMdv(traitCollection, modifiers));
   }
 
   @Test
@@ -38,7 +38,7 @@ public class CharacterUtilitiesTest {
     traitCollection.setValue(AbilityType.Dodge, 1);
     traitCollection.setValue(AttributeType.Dexterity, 2);
     traitCollection.setValue(OtherTraitType.Essence, 1);
-    assertEquals(1, CharacterUtilties.getDodgeDv(CharacterType.MORTAL, traitCollection, modifiers));
+    assertEquals(1, CharacterUtilities.getDodgeDv(CharacterType.MORTAL, traitCollection, modifiers));
   }
 
   @Test
@@ -46,7 +46,7 @@ public class CharacterUtilitiesTest {
     traitCollection.setValue(AbilityType.Dodge, 1);
     traitCollection.setValue(AttributeType.Dexterity, 2);
     traitCollection.setValue(OtherTraitType.Essence, 2);
-    assertEquals(2, CharacterUtilties.getDodgeDv(CharacterType.MORTAL, traitCollection, modifiers));
+    assertEquals(2, CharacterUtilities.getDodgeDv(CharacterType.MORTAL, traitCollection, modifiers));
   }
 
   @Test
@@ -54,7 +54,7 @@ public class CharacterUtilitiesTest {
     traitCollection.setValue(AbilityType.Dodge, 1);
     traitCollection.setValue(AttributeType.Dexterity, 1);
     traitCollection.setValue(OtherTraitType.Essence, 1);
-    assertEquals(1, CharacterUtilties.getDodgeDv(CharacterType.SOLAR, traitCollection, modifiers));
+    assertEquals(1, CharacterUtilities.getDodgeDv(CharacterType.SOLAR, traitCollection, modifiers));
   }
 
   @Test
@@ -62,7 +62,7 @@ public class CharacterUtilitiesTest {
     traitCollection.setValue(AbilityType.Dodge, 1);
     traitCollection.setValue(AttributeType.Dexterity, 1);
     traitCollection.setValue(OtherTraitType.Essence, 2);
-    assertEquals(2, CharacterUtilties.getDodgeDv(CharacterType.SOLAR, traitCollection, modifiers));
+    assertEquals(2, CharacterUtilities.getDodgeDv(CharacterType.SOLAR, traitCollection, modifiers));
   }
 
   @Test
@@ -70,6 +70,6 @@ public class CharacterUtilitiesTest {
     traitCollection.setValue(AbilityType.Dodge, 1);
     traitCollection.setValue(AttributeType.Dexterity, 2);
     traitCollection.setValue(OtherTraitType.Essence, 2);
-    assertEquals(3, CharacterUtilties.getDodgeDv(CharacterType.SOLAR, traitCollection, modifiers));
+    assertEquals(3, CharacterUtilities.getDodgeDv(CharacterType.SOLAR, traitCollection, modifiers));
   }
 }

--- a/Character_Lunar/src/net/sf/anathema/character/lunar/reporting/rendering/beastform/SecondEditionDBTCombatEncoder.java
+++ b/Character_Lunar/src/net/sf/anathema/character/lunar/reporting/rendering/beastform/SecondEditionDBTCombatEncoder.java
@@ -2,7 +2,7 @@ package net.sf.anathema.character.lunar.reporting.rendering.beastform;
 
 import net.sf.anathema.character.generic.character.IGenericTraitCollection;
 import net.sf.anathema.character.generic.equipment.IEquipmentModifiers;
-import net.sf.anathema.character.generic.impl.CharacterUtilties;
+import net.sf.anathema.character.generic.impl.CharacterUtilities;
 import net.sf.anathema.character.generic.type.ICharacterType;
 import net.sf.anathema.character.lunar.beastform.BeastformTemplate;
 import net.sf.anathema.character.lunar.beastform.presenter.IBeastformModel;
@@ -33,12 +33,12 @@ public class SecondEditionDBTCombatEncoder implements ContentEncoder {
     ICharacterType characterType = reportSession.getCharacter().getTemplate().getTemplateType().getCharacterType();
     IEquipmentModifiers equipment = reportSession.getCharacter().getEquipmentModifiers();
 
-    int joinBattle = CharacterUtilties.getJoinBattle(traitCollection, equipment);
-    int dodgeDV = CharacterUtilties.getDodgeDv(characterType, traitCollection, equipment);
-    int knockdownThreshold = CharacterUtilties.getKnockdownThreshold(traitCollection);
-    int knockdownPool = CharacterUtilties.getKnockdownPool(traitCollection);
-    int stunningThreshold = CharacterUtilties.getStunningThreshold(traitCollection);
-    int stunningPool = CharacterUtilties.getStunningPool(traitCollection);
+    int joinBattle = CharacterUtilities.getJoinBattle(traitCollection, equipment);
+    int dodgeDV = CharacterUtilities.getDodgeDv(characterType, traitCollection, equipment);
+    int knockdownThreshold = CharacterUtilities.getKnockdownThreshold(traitCollection);
+    int knockdownPool = CharacterUtilities.getKnockdownPool(traitCollection);
+    int stunningThreshold = CharacterUtilities.getStunningThreshold(traitCollection);
+    int stunningPool = CharacterUtilities.getStunningPool(traitCollection);
 
     String mobilityPenaltyLabel = "-" + resources.getString("Sheet.Combat.MobilityPenalty"); //$NON-NLS-1$ //$NON-NLS-2$
     String thresholdPoolLabel = resources.getString("Sheet.Combat.ThresholdPool"); //$NON-NLS-1$

--- a/Character_Reporting/src/net/sf/anathema/character/reporting/pdf/content/combat/AbstractCombatStatsContent.java
+++ b/Character_Reporting/src/net/sf/anathema/character/reporting/pdf/content/combat/AbstractCombatStatsContent.java
@@ -3,7 +3,7 @@ package net.sf.anathema.character.reporting.pdf.content.combat;
 import net.sf.anathema.character.generic.character.IGenericCharacter;
 import net.sf.anathema.character.generic.character.IGenericTraitCollection;
 import net.sf.anathema.character.generic.equipment.IEquipmentModifiers;
-import net.sf.anathema.character.generic.impl.CharacterUtilties;
+import net.sf.anathema.character.generic.impl.CharacterUtilities;
 import net.sf.anathema.character.generic.type.ICharacterType;
 import net.sf.anathema.character.reporting.pdf.content.AbstractSubBoxContent;
 import net.sf.anathema.lib.resources.IResources;
@@ -18,19 +18,19 @@ public abstract class AbstractCombatStatsContent extends AbstractSubBoxContent {
   }
 
   public int getKnockdownPool() {
-    return CharacterUtilties.getKnockdownPool(getCharacter());
+    return CharacterUtilities.getKnockdownPool(getCharacter());
   }
 
   public int getStunningThreshold() {
-    return CharacterUtilties.getStunningThreshold(getTraitCollection());
+    return CharacterUtilities.getStunningThreshold(getTraitCollection());
   }
 
   public int getKnockdownThreshold() {
-    return CharacterUtilties.getKnockdownThreshold(getTraitCollection());
+    return CharacterUtilities.getKnockdownThreshold(getTraitCollection());
   }
 
   public int getStunningPool() {
-    return CharacterUtilties.getStunningPool(getTraitCollection());
+    return CharacterUtilities.getStunningPool(getTraitCollection());
   }
 
   public String getKnockdownLabel() {

--- a/Character_Reporting/src/net/sf/anathema/character/reporting/pdf/rendering/boxes/social/SocialCombatStatsBoxEncoder.java
+++ b/Character_Reporting/src/net/sf/anathema/character/reporting/pdf/rendering/boxes/social/SocialCombatStatsBoxEncoder.java
@@ -7,7 +7,7 @@ import com.itextpdf.text.Rectangle;
 import com.itextpdf.text.pdf.PdfPTable;
 import net.sf.anathema.character.generic.character.IGenericTraitCollection;
 import net.sf.anathema.character.generic.equipment.IEquipmentModifiers;
-import net.sf.anathema.character.generic.impl.CharacterUtilties;
+import net.sf.anathema.character.generic.impl.CharacterUtilities;
 import net.sf.anathema.character.reporting.pdf.content.ReportSession;
 import net.sf.anathema.character.reporting.pdf.rendering.extent.Bounds;
 import net.sf.anathema.character.reporting.pdf.rendering.extent.Position;
@@ -127,8 +127,8 @@ public class SocialCombatStatsBoxEncoder implements ContentEncoder {
   private float encodeValues(SheetGraphics graphics, Bounds bounds, IGenericTraitCollection traitCollection, IEquipmentModifiers equipment) {
     String joinLabel = resources.getString("Sheet.SocialCombat.JoinDebateBattle"); //$NON-NLS-1$
     String dodgeLabel = resources.getString("Sheet.SocialCombat.DodgeMDV"); //$NON-NLS-1$
-    int joinDebate = CharacterUtilties.getJoinDebate(traitCollection, equipment);
-    int dodgeMDV = CharacterUtilties.getDodgeMdv(traitCollection, equipment);
+    int joinDebate = CharacterUtilities.getJoinDebate(traitCollection, equipment);
+    int dodgeMDV = CharacterUtilities.getDodgeMdv(traitCollection, equipment);
     Position upperLeftCorner = new Position(bounds.x, bounds.getMaxY());
     LabelledValueEncoder encoder = new LabelledValueEncoder(2, upperLeftCorner, bounds.width, 3);
     encoder.addLabelledValue(graphics, 0, joinLabel, joinDebate);

--- a/Character_Reporting_SecondEdition/src/net/sf/anathema/character/reporting/second/content/combat/CombatStatsContent.java
+++ b/Character_Reporting_SecondEdition/src/net/sf/anathema/character/reporting/second/content/combat/CombatStatsContent.java
@@ -1,7 +1,7 @@
 package net.sf.anathema.character.reporting.second.content.combat;
 
 import net.sf.anathema.character.generic.character.IGenericCharacter;
-import net.sf.anathema.character.generic.impl.CharacterUtilties;
+import net.sf.anathema.character.generic.impl.CharacterUtilities;
 import net.sf.anathema.character.reporting.pdf.content.combat.AbstractCombatStatsContent;
 import net.sf.anathema.character.reporting.pdf.content.combat.CombatAction;
 import net.sf.anathema.character.reporting.pdf.content.general.QualifiedText;
@@ -25,11 +25,11 @@ public class CombatStatsContent extends AbstractCombatStatsContent {
   }
 
   public int getJoinBattle() {
-    return CharacterUtilties.getJoinBattle(getTraitCollection(), getEquipment());
+    return CharacterUtilities.getJoinBattle(getTraitCollection(), getEquipment());
   }
 
   public int getDodgeDv() {
-    return CharacterUtilties.getDodgeDv(getCharacterType(), getTraitCollection(), getEquipment());
+    return CharacterUtilities.getDodgeDv(getCharacterType(), getTraitCollection(), getEquipment());
   }
 
   public String[] getAttacks() {

--- a/Lib/test/net/sf/anathema/lib/lang/ArrayUtilitiesTest.java
+++ b/Lib/test/net/sf/anathema/lib/lang/ArrayUtilitiesTest.java
@@ -5,7 +5,7 @@ import java.util.Arrays;
 import org.junit.Assert;
 import org.junit.Test;
 
-public class ArrayUtiltiesTest {
+public class ArrayUtilitiesTest {
 
   @Test
   public void testMoveToGreaterIndex() throws Exception {


### PR DESCRIPTION
The word Utilities (Util i ties) was misspelled as Utilties (Util ties) in many places. The biggest culprit was CharacterUtilities.java, and every file that referred to it. I corrected all misspellings and performed a "gradlew clean test" to ensure everything compiled properly and all unit tests passed.
