### PR TITLE
Fix for NullPointerException when launching Anathema from a fresh install.

### DIFF
--- a/Character_Equipment_Impl/src/net/sf/anathema/character/equipment/impl/module/DatabaseConversionBootJob.java
+++ b/Character_Equipment_Impl/src/net/sf/anathema/character/equipment/impl/module/DatabaseConversionBootJob.java
@@ -38,7 +38,10 @@ public class DatabaseConversionBootJob implements IAnathemaBootJob {
     ObjectContainer container = EquipmentDatabaseConnectionManager.createConnection(databaseFile);
     Version dbVersion = DatabaseUtils.getDatabaseVersion(container);
     Version anathemaVersion = new Version(resources);
-    logger.info("Found equipment database at version " + dbVersion.asString());
+    if( dbVersion != null )
+		logger.info("Found equipment database at version " + dbVersion.asString());
+	else
+		logger.info("No equipment database found, creating new empty database");
     if (anathemaVersion.isLargerThan(dbVersion)) {
       backupDatabase(anathemaModel, container, anathemaVersion);
       Version updatedVersion = updateDbVersion(dbVersion, anathemaVersion);


### PR DESCRIPTION
When you try to run Anathema from a freshly built installation, it causes a NullPointerException.

When it uses `DatabaseUtils.getDatabaseVersion()` on a non-existant database, it returns null.  The null is checked for in several places, but not in the new `logger.info()` statement added in [this commit](https://github.com/anathema/anathema/commit/7d6e90add41fbf49bb4f7c2cd0d5b1e87158f75d). Calling `dbVersion.asString()` when dbVersion is null throws this exception.

The null checks currently in place for this use case are in the following functions:
- `Version.isLargerThan( Version )`
- `Version.equals( Version )`
- `DatabaseConversionBootJob.updateDbVersion( Version, Version )`

I added another null check in `DatabaseConversionBootJob.run()` around the `logger.info()` statement to handle this particular exception.  Honestly I'd love to see either a null check in `Version.compareTo( Version )`, or just make it private, as its being used by `Version.equals( Version )` and `Version.isLargerThan( Version )`, both of which have null checks already.

My fix may not be exactly what you were looking for, so feel free to change it.
On a side note, why create a `Version.asString()` method?  Why not just overload `Version.toString()`?
