### PR TITLE
New Feature: Show Join Battle Specialty on character sheet next to Join Battle Pool

### DIFF
--- a/Character_Generic_Impl/src/net/sf/anathema/character/generic/impl/CharacterUtilities.java
+++ b/Character_Generic_Impl/src/net/sf/anathema/character/generic/impl/CharacterUtilities.java
@@ -40,6 +40,12 @@ public class CharacterUtilities {
     baseValue += equipment.getJoinBattleMod();
     return Math.max(baseValue, 1);
   }
+  
+  public static int getJoinBattleWithSpecialty(IGenericTraitCollection traitCollection, ICharacterStatsModifiers equipment, int awarenessSpecialty) {
+    int baseValue = getJoinBattle( traitCollection, equipment );
+    baseValue += awarenessSpecialty;
+    return Math.max(baseValue, 1);
+  }
 
   public static int getJoinDebate(IGenericTraitCollection traitCollection, ICharacterStatsModifiers equipment) {
     int baseValue = getTotalValue(traitCollection, AttributeType.Wits, AbilityType.Awareness);

--- a/Character_Lunar/src/net/sf/anathema/character/lunar/reporting/rendering/beastform/SecondEditionDBTCombatEncoder.java
+++ b/Character_Lunar/src/net/sf/anathema/character/lunar/reporting/rendering/beastform/SecondEditionDBTCombatEncoder.java
@@ -35,9 +35,11 @@ public class SecondEditionDBTCombatEncoder implements ContentEncoder {
     IGenericTraitCollection traitCollection = additionalModel.getBeastTraitCollection();
     ICharacterType characterType = reportSession.getCharacter().getTemplate().getTemplateType().getCharacterType();
     ICharacterStatsModifiers equipment = CharacterStatsModifiers.extractFromCharacter(reportSession.getCharacter());
+    HighestSpecialty awarenessSpecialty = new HighestSpecialty( reportSession.getCharacter(), AbilityType.Awareness );
     HighestSpecialty dodgeSpecialty = new HighestSpecialty( reportSession.getCharacter(), AbilityType.Dodge );
     
     int joinBattle = CharacterUtilities.getJoinBattle(traitCollection, equipment);
+    int joinBattleWithSpecialty = CharacterUtilities.getJoinBattleWithSpecialty(traitCollection, equipment, awarenessSpecialty.getValue());
     int dodgeDV = CharacterUtilities.getDodgeDv(characterType, traitCollection, equipment);
     int dodgeDVWithSpecialty = CharacterUtilities.getDodgeDvWithSpecialty(characterType, traitCollection, equipment, dodgeSpecialty.getValue());
     int knockdownThreshold = CharacterUtilities.getKnockdownThreshold(traitCollection);
@@ -45,12 +47,12 @@ public class SecondEditionDBTCombatEncoder implements ContentEncoder {
     int stunningThreshold = CharacterUtilities.getStunningThreshold(traitCollection);
     int stunningPool = CharacterUtilities.getStunningPool(traitCollection);
 
+    String joinSpecialtyLabel = resources.getString("Sheet.Combat.NormalSpecialty") + awarenessSpecialty; //$NON-NLS-1$
     String dodgeSpecialtyLabel = resources.getString("Sheet.Combat.NormalSpecialty") + dodgeSpecialty; //$NON-NLS-1$
     String thresholdPoolLabel = resources.getString("Sheet.Combat.ThresholdPool"); //$NON-NLS-1$
     Position upperLeftCorner = new Position(bounds.x, bounds.getMaxY());
     LabelledValueEncoder encoder = new LabelledValueEncoder(2, upperLeftCorner, bounds.width, 3);
-    encoder.addLabelledValue(graphics, 0, joinLabel, joinBattle);
-
+    displayJoinBattleWithSpecialty( graphics, encoder, joinLabel, joinBattle, joinBattleWithSpecialty, joinSpecialtyLabel);
     displayDodgeWithSpecialty(graphics, encoder, dodgeLabel, dodgeDV, dodgeDVWithSpecialty, dodgeSpecialtyLabel);
     upperLeftCorner = new Position(bounds.x, bounds.getMaxY() - 25);
     encoder = new LabelledValueEncoder(2, upperLeftCorner, bounds.width, 3);
@@ -69,6 +71,15 @@ public class SecondEditionDBTCombatEncoder implements ContentEncoder {
   @Override
   public String getHeader(ReportSession session) {
     return resources.getString("Sheet.Header.Lunar.WarForm.CombatValues");
+  }
+  
+  private void displayJoinBattleWithSpecialty( SheetGraphics graphics, LabelledValueEncoder encoder, String joinLabel, int joinBattle, int joinBattleWithSpecialty, String joinBattleSpecialtyLabel ) {
+      if( joinBattle != joinBattleWithSpecialty ) {
+        encoder.addLabelledValue(graphics, 0, joinLabel, joinBattle, joinBattleWithSpecialty);
+        encoder.addComment(graphics, joinBattleSpecialtyLabel, 0);
+      } else {
+        encoder.addLabelledValue(graphics, 0, joinLabel, joinBattle);
+      }
   }
   
   private void displayDodgeWithSpecialty( SheetGraphics graphics, LabelledValueEncoder encoder, String dodgeLabel, int dodgeDV, int dodgeDVWithSpecialty, String dodgeSpecialtyLabel ) {

--- a/Character_Reporting_SecondEdition/src/net/sf/anathema/character/reporting/second/content/combat/CombatStatsContent.java
+++ b/Character_Reporting_SecondEdition/src/net/sf/anathema/character/reporting/second/content/combat/CombatStatsContent.java
@@ -15,10 +15,12 @@ import static net.sf.anathema.character.reporting.pdf.content.general.TextType.N
 public class CombatStatsContent extends AbstractCombatStatsContent {
 
   private HighestSpecialty dodgeSpecialty;
+  private HighestSpecialty awarenessSpecialty;
 
   protected CombatStatsContent(IGenericCharacter character, IResources resources) {
     super(resources, character);
     dodgeSpecialty = new HighestSpecialty( character, AbilityType.Dodge );
+    awarenessSpecialty = new HighestSpecialty( character, AbilityType.Awareness );
   }
 
   public String getJoinLabel() {
@@ -29,12 +31,20 @@ public class CombatStatsContent extends AbstractCombatStatsContent {
     return getString("Sheet.Combat.DodgeDV"); //$NON-NLS-1$
   }
   
+  public String getJoinBattleSpecialtyLabel() {
+    return getString( "Sheet.Combat.NormalSpecialty" ) + awarenessSpecialty; //$NON-NLS-1$
+  }
+  
   public String getDodgeSpecialtyLabel() {
     return getString( "Sheet.Combat.NormalSpecialty" ) + dodgeSpecialty; //$NON-NLS-1$
   }
 
   public int getJoinBattle() {
     return CharacterUtilities.getJoinBattle(getTraitCollection(), getEquipment());
+  }
+  
+  public int getJoinBattleWithSpecialty() {
+    return CharacterUtilities.getJoinBattleWithSpecialty(getTraitCollection(), getEquipment(), awarenessSpecialty.getValue());
   }
 
   public int getDodgeDv() {

--- a/Character_Reporting_SecondEdition/src/net/sf/anathema/character/reporting/second/rendering/combat/CombatValueEncoder.java
+++ b/Character_Reporting_SecondEdition/src/net/sf/anathema/character/reporting/second/rendering/combat/CombatValueEncoder.java
@@ -15,7 +15,7 @@ public class CombatValueEncoder implements IContentEncoder {
     CombatStatsContent content = createContent(reportSession);
     Position upperLeft = new Position(bounds.x, bounds.getMaxY());
     LabelledValueEncoder encoder = new LabelledValueEncoder(4, upperLeft, bounds.width, 3);
-    encoder.addLabelledValue(graphics, 0, content.getJoinLabel(), content.getJoinBattle());
+    displayJoinBattleWithSpecialty( graphics, encoder, content );
     displayDodgeWithSpecialty( graphics, encoder, content );
     encoder.addLabelledValue(graphics, 2, content.getKnockdownLabel(), content.getKnockdownThreshold(), content.getKnockdownPool());
     encoder.addLabelledValue(graphics, 3, content.getStunningLabel(), content.getStunningThreshold(), content.getStunningPool());
@@ -28,6 +28,15 @@ public class CombatValueEncoder implements IContentEncoder {
     return session.createContent(CombatStatsContent.class);
   }
   
+  private void displayJoinBattleWithSpecialty(  SheetGraphics graphics, LabelledValueEncoder encoder, CombatStatsContent content ) {
+      if( content.getJoinBattle() != content.getJoinBattleWithSpecialty() ) {
+          encoder.addLabelledValue(graphics, 0, content.getJoinLabel(), content.getJoinBattle(), content.getJoinBattleWithSpecialty());
+          encoder.addComment(graphics, content.getJoinBattleSpecialtyLabel(), 0);
+      } else {
+          encoder.addLabelledValue(graphics, 0, content.getJoinLabel(), content.getJoinBattle());
+      }
+  }
+      
   private void displayDodgeWithSpecialty( SheetGraphics graphics, LabelledValueEncoder encoder, CombatStatsContent content ) {
       if( content.getDodgeDv() != content.getDodgeDvWithSpecialty() ) {
           encoder.addLabelledValue(graphics, 1, content.getDodgeLabel(), content.getDodgeDv(), content.getDodgeDvWithSpecialty());
@@ -36,5 +45,4 @@ public class CombatValueEncoder implements IContentEncoder {
           encoder.addLabelledValue(graphics, 1, content.getDodgeLabel(), content.getDodgeDv());
       }     
   }
-  
 }


### PR DESCRIPTION
While fiddling with the Dodge Specialty feature, I worked on this feature in tandem.  It uses some of the same code, and is implemented in exactly the same manner as the Dodge Specialty feature.
- If the character has an awareness specialty, it finds the highest dot value specialty.
- It adds this specialty value to Join Battle, and displays the new total value next to the existing Join Battle.
- It only displays this value if there is an awareness specialty.
- It displays a comment under the Join Battle section, using the name of the specialty.  ex: "Normal / Sensing Ambushes".

I'm not entirely sure this feature is needed/wanted.  While manually calculating your dodge DV based on your specialty can be a pain because of the division by 2 and the rounding, calculating join battle with a specialty is just a matter of simple addition.

That said, it was a trivial feature to implement, and it looks cool if your character has an awareness specialty.  
