### PR TITLE
Removed "Close" tooltip when hovering over the X icon on a tab.

### DIFF
--- a/Platform/resources/data/language/platform/anathema.properties
+++ b/Platform/resources/data/language/platform/anathema.properties
@@ -10,7 +10,7 @@ AnathemaCore.Tools.Close.DirtyQuestion=There are unsaved changes.\nClose anyway?
 AnathemaCore.Tools.Question.Okay=Yes
 AnathemaCore.Tools.Question.Cancel=No
 AnathemaCore.Tools.Exit.Name=Quit
-AnathemaCore.Tools.Close.Tooltip=Close
+#not used anymore# AnathemaCore.Tools.Close.Tooltip=Close
 AnathemaCore.Tools.Preferences.Name=Preferences
 AnathemaCore.Tools.Preferences.Instruction=Please set your preferences.
 

--- a/Platform/resources/data/language/platform/anathema_es.properties
+++ b/Platform/resources/data/language/platform/anathema_es.properties
@@ -9,7 +9,7 @@ AnathemaCore.Tools.Close.DirtyQuestion=Hay cambios sin guardar.\n¿Cerrar de todo
 AnathemaCore.Tools.Question.Okay=Si
 ##AnathemaCore.Tools.Question.Cancel=No
 AnathemaCore.Tools.Exit.Name=Salir
-AnathemaCore.Tools.Close.Tooltip=Cerrar
+#not used anymore# AnathemaCore.Tools.Close.Tooltip=Cerrar
 AnathemaCore.Tools.Preferences.Name=Preferencias
 AnathemaCore.Tools.Preferences.Instruction=Por favor pon tus preferencias.
 

--- a/Platform/resources/data/language/platform/anathema_it.properties
+++ b/Platform/resources/data/language/platform/anathema_it.properties
@@ -9,7 +9,7 @@ AnathemaCore.Tools.Close.DirtyQuestion=Ci sono modifiche non salvate.
 AnathemaCore.Tools.Question.Okay=Si
 AnathemaCore.Tools.Question.Cancel=No
 AnathemaCore.Tools.Exit.Name=Esci
-AnathemaCore.Tools.Close.Tooltip=Chiudi
+#not used anymore# AnathemaCore.Tools.Close.Tooltip=Chiudi
 AnathemaCore.Tools.Preferences.Name=Preferenze
 AnathemaCore.Tools.Preferences.Instruction=Perfavore imposta le tue preferenze.
 

--- a/Platform/src/net/sf/anathema/framework/presenter/itemmanagement/AnathemaItemCloseAction.java
+++ b/Platform/src/net/sf/anathema/framework/presenter/itemmanagement/AnathemaItemCloseAction.java
@@ -15,7 +15,6 @@ public class AnathemaItemCloseAction extends AbstractAnathemaCloseAction {
 
   public static Action createForItem(IItemManagementModel model, IResources resources, IItem item) {
     SmartAction action = new AnathemaItemCloseAction(model, item, resources);
-    action.setToolTipText(resources.getString("AnathemaCore.Tools.Close.Tooltip")); //$NON-NLS-1$
     action.setIcon(new BasicUi(resources).getClearIcon());
     return action;
   }

--- a/Platform/src/net/sf/anathema/framework/view/item/ItemViewManagement.java
+++ b/Platform/src/net/sf/anathema/framework/view/item/ItemViewManagement.java
@@ -47,6 +47,8 @@ public class ItemViewManagement implements IComponentItemViewManagement {
     titledTabProperties.addSuperObject(theme.getTitledTabProperties());
     titledTabProperties.getNormalProperties().setTitleComponentVisible(false);
     titledTabProperties.getHighlightedProperties().setTitleComponentVisible(true);
+	titledTabProperties.setFocusable(false);
+	titledTabProperties.setHighlightedRaised(3);
     titledTabProperties.setHoverListener(new HoverListener() {
       @Override
       public void mouseEntered(HoverEvent event) {


### PR DESCRIPTION
As mentioned in [#154](https://github.com/anathema/anathema/issues/154), there is really no reason for a "Close" tooltip for this.  Its blatantly obvious what the red X icon does.  Also, the tooltip being un-clickable and covering the button under the user's mouse can happen a surprising amount of the time, when the program is run full-screen.  If we decide the tooltip is warranted, we can always add it back, but attempt to shift it to the upper-right of the cursor, where it won't collide with the edge of the screen and get pushed up.

While I was mucking around there, I also fixed a longstanding annoyance:
- When you click on a tab that is already selected, it no longer puts a rectangle around the tab text.

I also added a very subtle change:
- The currently selected tab now has its height raised by 3 pixels, to help indicate it is the one currently selected.
