### PR TITLE
Clinch tagged weapons now use the higher of their Str or Dex for calculating accuracy.

### DIFF
--- a/Character_Equipment_Impl/src/net/sf/anathema/character/equipment/impl/reporting/content/stats/weapons/AccuracyWeaponStatsGroup.java
+++ b/Character_Equipment_Impl/src/net/sf/anathema/character/equipment/impl/reporting/content/stats/weapons/AccuracyWeaponStatsGroup.java
@@ -8,8 +8,12 @@ import net.sf.anathema.character.equipment.character.model.IEquipmentStatsOption
 import net.sf.anathema.character.equipment.impl.reporting.content.stats.AbstractValueEquipmentStatsGroup;
 import net.sf.anathema.character.generic.character.IGenericTraitCollection;
 import net.sf.anathema.character.generic.equipment.weapon.IWeaponStats;
+import net.sf.anathema.character.equipment.impl.creation.model.WeaponTag;
 import net.sf.anathema.character.generic.traits.types.AttributeType;
+import net.sf.anathema.character.generic.traits.IGenericTrait;
 import net.sf.anathema.lib.resources.IResources;
+
+import java.util.Arrays;
 
 public class AccuracyWeaponStatsGroup extends AbstractValueEquipmentStatsGroup<IWeaponStats> {
 
@@ -56,7 +60,14 @@ public class AccuracyWeaponStatsGroup extends AbstractValueEquipmentStatsGroup<I
   }
 
   protected int getFinalValue(IWeaponStats weapon, int weaponValue) {
-    return calculateFinalValue(weaponValue + getOptionModifiers(weapon), collection.getTrait(AttributeType.Dexterity),
+    IGenericTrait trait = collection.getTrait(AttributeType.Dexterity);
+    if( Arrays.asList( weapon.getTags() ).contains( WeaponTag.ClinchEnhancer ) ) {
+      IGenericTrait str = collection.getTrait(AttributeType.Strength);
+      if( trait.getCurrentValue() < str.getCurrentValue() ) {
+        trait = str;
+      }
+    }
+    return calculateFinalValue(weaponValue + getOptionModifiers(weapon), trait,
             collection.getTrait(weapon.getTraitType()));
   }
 }

--- a/Development_Documentation/Distribution/English/versions.txt
+++ b/Development_Documentation/Distribution/English/versions.txt
@@ -48,6 +48,7 @@ printed them.
 * Fixed free Virtue cap for non-Solars at character creation
 * [Shadow493] First Age Solars have the correct points
 * [Curtis Tasker] Item stats can contain the '&' character
+* [Curtis Tasker] Clinch attacks now calculate using the higher of your Strength or Dexterity
 * Hero style extension Charms are only available to matching Exalts
 * (Solar/Melee) "Honored Companion of the Sun" is present
 * (Solar/Melee) "Deft Hands Deflection" has correct cost


### PR DESCRIPTION
Fixes issue #178.  Page 157, 158, and 373 in 2E Core verify the rule.
