### PR TITLE
Adds a 'run' task to gradle.  "gradlew run" compiles and runs Anathema from the command-line.

### DIFF
--- a/Anathema/build.gradle
+++ b/Anathema/build.gradle
@@ -1,5 +1,10 @@
 archivesBaseName= 'anathema'
 
+task(run, dependsOn: compileJava, type: JavaExec) {
+  main = "net.sf.anathema.AnathemaBootLoader"
+  classpath = sourceSets.main.runtimeClasspath
+}
+
 jar {
   manifest {
     attributes(


### PR DESCRIPTION
I've had this change in my local development environment since day 1.  It allows me to type `gradlew run` at the command line, and have it build Anathema and run it straight from the command line.  Basically this piggybacks on the classpath built by gradle to execute the code.

Obviously, the ability to execute the application without performing a full deployment build and install is required for viable development without an IDE.
