### PR TITLE
Lunar CMA costs at anathema are listed wrong.

### DIFF
--- a/Character_Lunar/resources/data/template/LunarMagic2nd.template
+++ b/Character_Lunar/resources/data/template/LunarMagic2nd.template
@@ -3,7 +3,7 @@
 	<favoringTraitType type="AttributeType"/>
 	<charmTemplate charmType="Lunar">
 	    <hasUniqueCharmType type="Knacks" label="Lunar.Knacks" keyword="Knack"/>
-		<martialArts level="Terrestrial" highLevel="true" /> 
+		<martialArts level="Celestial" highLevel="false" /> 
 	</charmTemplate>
 	<spellTemplate maximumSorceryCircle="Celestial" maximumNecromancyCircle="Shadowlands"/>
 </magicTemplate>		


### PR DESCRIPTION
In the current version of anathema, lunar CMA costs 12 XP for favored CMA charms and 15 XP for non favored CMA charms.
So I changed the code to allow every lunar acess CMA charms as default and disallow SMA charms.
See Manual of Exalted Powers: Lunars p. 233.
Thanks in advance.
