### PR TITLE
Minor build cleanup

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,9 +42,6 @@ subprojects {
     maven {
       url 'https://github.com/anathema/anathema-thirdparty/raw/master/releases/'
     }
-    maven {
-      url 'https://github.com/anathema/anathema-thirdparty/raw/master/snapshots/'
-    }
   }
 
   sourceSets.main.java.srcDir 'src'
@@ -112,7 +109,6 @@ task release << {
   // grab the latest updates for this release from versions.md and put into readme.md for sourceforge
   String delim = "## Release "
   String releaseNotes = new File("Development_Documentation/Distribution/English/versions.md").getText( 'UTF-8' ) 
-  String[] versions = releaseNotes.split( delim )[1];
   new File("${buildDir}/readme.md").write( delim + releaseNotes.split( delim )[1], 'UTF-8' )
 }
 


### PR DESCRIPTION
I poked around the debug log files a bit further where it was hanging on "404 Not Found" errors.  Even after deleting my `~/.gradle/caches` folder, it still seemed to want to check the snapshots folder for `/anathema/anathema-thirdparty/raw/master/snapshots/javazoom/mp3spi/1.9.2/mp3spi-1.9.2.pom` and `/anathema/anathema-thirdparty/raw/master/snapshots/javazoom/jlgui/2.3.0/jlgui-2.3.0.pom` (and possibly more that I missed), even though they already existed in the release folders. Its clear from the logs that gradle was finding the resources in releases, but then double-checking for some of them in snapshots.

Anyways, I double-checked and you're right, we are no longer using any resources in the snapshots folder.  I'm not sure why gradle keeps trying to grab things from the snapshot folder, but I figured it was time to sidestep the issue.

I removed the snapshot folder from the list of maven repositories, and it no longer exhibits this behavior.  Initial builds on new machines are now very, very fast.  We can safely remove the snapshots from https://github.com/anathema/anathema-thirdparty.
