### PR TITLE
Linux anathema.sh overhaul

### DIFF
--- a/Development_Distribution/Linux/anathema.sh
+++ b/Development_Distribution/Linux/anathema.sh
@@ -11,7 +11,7 @@ while [ -h "$SOURCE" ]; do
   [[ $SOURCE != /* ]] && SOURCE="$DIR/$SOURCE" 
 done
 ANATHEMA_DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
-REPO_DIR=${HOME}/.anathema/repository
+REPO_DIR=${1-${HOME}/.anathema/repository}
 JAVA_BIN=
 
 # Check for java in $JAVA_HOME


### PR DESCRIPTION
Do not force users to install anathema on /usr/share/anathema
This patch will use standard shell scripting to detect the real
anathema installation folder.

When invoking anathema.sh if an argument is provided this will
override the default repository path.

I made this patches on Anathema_2e because it's the one that I use, I've checked the master branch and this 2 commits can safely be cherry-picked
