### PR TITLE
macOS DMG installer + run on a modern, redistributable JavaFX 8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,7 @@ repository.version
 
 #Special Cases
 !/Campaign_Scribe_Conversion/src/test/resources/Input.not
+
+# Packaged installers
+/dist/
+.DS_Store

--- a/Character_Equipment/src/main/java/net/sf/anathema/character/equipment/creation/view/fx/FxEditStatsDialog.java
+++ b/Character_Equipment/src/main/java/net/sf/anathema/character/equipment/creation/view/fx/FxEditStatsDialog.java
@@ -1,36 +1,29 @@
 package net.sf.anathema.character.equipment.creation.view.fx;
 
-import javafx.event.ActionEvent;
 import net.sf.anathema.character.equipment.creation.presenter.EquipmentStatsDialog;
 import net.sf.anathema.character.equipment.creation.presenter.EquipmentStatsView;
 import net.sf.anathema.framework.environment.fx.DialogFactory;
+import net.sf.anathema.framework.fx.compat.Dialog;
 import net.sf.anathema.lib.gui.dialog.core.StaticOperationResult;
 import net.sf.anathema.lib.gui.dialog.userdialog.OperationResultHandler;
 import net.sf.anathema.lib.message.Message;
-import org.controlsfx.control.action.AbstractAction;
-import org.controlsfx.dialog.Dialog;
+import org.controlsfx.control.action.Action;
 
 public class FxEditStatsDialog implements EquipmentStatsDialog {
-  private final AbstractAction okayAction = new AbstractAction(Dialog.Actions.OK.textProperty().get()){
-    @Override
-    public void handle(ActionEvent actionEvent) {
-      dialog.hide();
-      handler.handleOperationResult(StaticOperationResult.Confirmed());
-    }
-  };
-  private final AbstractAction cancelAction = new AbstractAction(Dialog.Actions.CANCEL.textProperty().get()){
-    @Override
-    public void handle(ActionEvent actionEvent) {
-      dialog.hide();
-      handler.handleOperationResult(StaticOperationResult.Canceled());
-    }
-  };
   private final FxEquipmentStatsView view = new FxEquipmentStatsView();
   private Dialog dialog;
   private String title;
   private OperationResultHandler handler;
   private String messageText;
   private DialogFactory dialogFactory;
+  private final Action okayAction = new Action(Dialog.Actions.OK.getText(), actionEvent -> {
+    dialog.hide();
+    handler.handleOperationResult(StaticOperationResult.Confirmed());
+  });
+  private final Action cancelAction = new Action(Dialog.Actions.CANCEL.getText(), actionEvent -> {
+    dialog.hide();
+    handler.handleOperationResult(StaticOperationResult.Canceled());
+  });
 
   public FxEditStatsDialog(DialogFactory dialogFactory) {
     this.dialogFactory = dialogFactory;

--- a/Character_Main_FX/src/main/java/net/sf/anathema/fx/hero/creation/ConfigurableControlsFxAction.java
+++ b/Character_Main_FX/src/main/java/net/sf/anathema/fx/hero/creation/ConfigurableControlsFxAction.java
@@ -1,22 +1,19 @@
 package net.sf.anathema.fx.hero.creation;
 
-import javafx.event.ActionEvent;
 import net.sf.anathema.interaction.Command;
-import org.controlsfx.control.action.AbstractAction;
+import org.controlsfx.control.action.Action;
 
-public class ConfigurableControlsFxAction extends AbstractAction {
+public class ConfigurableControlsFxAction extends Action {
   private Command command;
 
   public ConfigurableControlsFxAction(String text) {
     super(text);
   }
 
+  // Action.handle(ActionEvent) is final in ControlsFX 8.40+, so behaviour is supplied through the
+  // event-handler consumer rather than by overriding handle.
   public void setCommand(Command command) {
     this.command = command;
-  }
-
-  @Override
-  public void handle(ActionEvent actionEvent) {
-    command.execute();
+    setEventHandler(actionEvent -> command.execute());
   }
 }

--- a/Character_Main_FX/src/main/java/net/sf/anathema/fx/hero/creation/FxCharacterCreationView.java
+++ b/Character_Main_FX/src/main/java/net/sf/anathema/fx/hero/creation/FxCharacterCreationView.java
@@ -11,13 +11,12 @@ import net.sf.anathema.hero.creation.ToggleButtonPanel;
 import net.sf.anathema.hero.template.HeroTemplate;
 import net.sf.anathema.interaction.Tool;
 import net.sf.anathema.lib.gui.selection.VetoableObjectSelectionView;
+import net.sf.anathema.framework.fx.compat.Dialog;
 import net.sf.anathema.platform.fx.ListSelectionView;
-import org.controlsfx.dialog.Dialog;
 import org.tbee.javafx.scene.layout.MigPane;
 
 import static javafx.scene.control.ScrollPane.ScrollBarPolicy.AS_NEEDED;
 import static javafx.scene.control.ScrollPane.ScrollBarPolicy.NEVER;
-import static org.controlsfx.dialog.DialogStyle.NATIVE;
 
 public class FxCharacterCreationView implements CharacterCreationView {
 

--- a/Platform/src/main/java/net/sf/anathema/framework/repository/preferences/RepositoryPreferenceModel.java
+++ b/Platform/src/main/java/net/sf/anathema/framework/repository/preferences/RepositoryPreferenceModel.java
@@ -15,7 +15,10 @@ import java.nio.file.Paths;
 @RegisteredPreferenceModel
 public class RepositoryPreferenceModel implements PreferenceModel {
   public static final PreferenceKey key = new PreferenceKey("framework.repository.location");
-  public static final String DEFAULT_REPOSITORY_LOCATION = "./repository/";
+  // Use an absolute, per-user location (the %USER_HOME% token is expanded by
+  // RepositoryLocationResolver). A relative "./repository/" default fails for a packaged macOS
+  // .app, whose working directory is "/" and is not writable. Matches the Linux launcher default.
+  public static final String DEFAULT_REPOSITORY_LOCATION = "%USER_HOME%/.anathema/repository/";
   private final Path defaultPath = Paths.get(DEFAULT_REPOSITORY_LOCATION);
   private final Announcer<ChangeListener> announcer = Announcer.to(ChangeListener.class);
   private Path repositoryPath;

--- a/Platform/src/main/resources/logback.xml
+++ b/Platform/src/main/resources/logback.xml
@@ -7,7 +7,9 @@
   </appender>
 
   <appender name="FILE" class="ch.qos.logback.core.FileAppender">
-    <file>runtime.log</file>
+    <!-- Absolute, per-user path: a packaged app's working directory ("/") is read-only.
+         logback creates the parent directory if it is missing. -->
+    <file>${user.home}/.anathema/runtime.log</file>
     <encoder>
       <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
     </encoder>

--- a/Platform_FX/build.gradle
+++ b/Platform_FX/build.gradle
@@ -2,6 +2,6 @@ dependencies {
     compile 'com.miglayout:miglayout-javafx:5.0'
     compile 'org.jfxtras:jfxtras-controls:8.0-r1'
     compile 'org.jfxtras:jfxtras-labs:8.0-r1'
-    compile 'org.controlsfx:controlsfx:8.0.6'
+    compile 'org.controlsfx:controlsfx:8.40.18'
     compile project(':Platform')
 }

--- a/Platform_FX/src/main/java/net/sf/anathema/framework/environment/fx/DialogFactory.java
+++ b/Platform_FX/src/main/java/net/sf/anathema/framework/environment/fx/DialogFactory.java
@@ -1,6 +1,6 @@
 package net.sf.anathema.framework.environment.fx;
 
-import org.controlsfx.dialog.Dialog;
+import net.sf.anathema.framework.fx.compat.Dialog;
 
 public interface DialogFactory {
   Dialog createDialog(String title);

--- a/Platform_FX/src/main/java/net/sf/anathema/framework/environment/fx/FxUiEnvironment.java
+++ b/Platform_FX/src/main/java/net/sf/anathema/framework/environment/fx/FxUiEnvironment.java
@@ -9,11 +9,11 @@ import net.sf.anathema.interaction.ProxyAcceleratorMap;
 import net.sf.anathema.lib.gui.file.Extension;
 import net.sf.anathema.lib.gui.file.FileChooserConfiguration;
 import net.sf.anathema.lib.gui.file.SingleFileChooser;
-import org.controlsfx.dialog.Dialog;
+import net.sf.anathema.framework.fx.compat.Dialog;
 
 import java.nio.file.Path;
 
-import static org.controlsfx.dialog.DialogStyle.NATIVE;
+import static net.sf.anathema.framework.fx.compat.DialogStyle.NATIVE;
 
 public class FxUiEnvironment implements UiEnvironment {
 

--- a/Platform_FX/src/main/java/net/sf/anathema/framework/fx/FxDialogExceptionHandler.java
+++ b/Platform_FX/src/main/java/net/sf/anathema/framework/fx/FxDialogExceptionHandler.java
@@ -3,9 +3,9 @@ package net.sf.anathema.framework.fx;
 import javafx.stage.Window;
 import net.sf.anathema.framework.environment.ExceptionHandler;
 import net.sf.anathema.framework.environment.Resources;
-import org.controlsfx.dialog.Dialogs;
+import net.sf.anathema.framework.fx.compat.Dialogs;
 
-import static org.controlsfx.dialog.DialogStyle.NATIVE;
+import static net.sf.anathema.framework.fx.compat.DialogStyle.NATIVE;
 
 public class FxDialogExceptionHandler implements ExceptionHandler {
 

--- a/Platform_FX/src/main/java/net/sf/anathema/framework/fx/compat/Dialog.java
+++ b/Platform_FX/src/main/java/net/sf/anathema/framework/fx/compat/Dialog.java
@@ -1,0 +1,132 @@
+package net.sf.anathema.framework.fx.compat;
+
+import javafx.collections.FXCollections;
+import javafx.collections.ObservableList;
+import javafx.geometry.Insets;
+import javafx.geometry.Pos;
+import javafx.scene.Node;
+import javafx.scene.Scene;
+import javafx.scene.control.Button;
+import javafx.scene.control.ButtonType;
+import javafx.scene.control.Label;
+import javafx.scene.layout.BorderPane;
+import javafx.scene.layout.HBox;
+import javafx.stage.Modality;
+import javafx.stage.Stage;
+import javafx.stage.Window;
+import org.controlsfx.control.action.Action;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Compatibility replacement for the lightweight {@code org.controlsfx.dialog.Dialog} that ControlsFX
+ * removed after 8.0.x. It reproduces the slice of behaviour Anathema relies on — a modal window with
+ * an optional masthead, a content node, and a row of buttons built from {@link Action}s — on top of a
+ * plain JavaFX {@link Stage}. Built-in actions ({@link Actions}) close the dialog when clicked; custom
+ * actions simply run their handler.
+ */
+public class Dialog {
+
+  /** Built-in actions, kept as identity constants so callers can compare with {@code ==}. */
+  public static final class Actions {
+    public static final Action OK = new Action(ButtonType.OK.getText());
+    public static final Action CANCEL = new Action(ButtonType.CANCEL.getText());
+    public static final Action CLOSE = new Action(ButtonType.CLOSE.getText());
+    public static final Action YES = new Action(ButtonType.YES.getText());
+    public static final Action NO = new Action(ButtonType.NO.getText());
+
+    private Actions() {
+    }
+  }
+
+  private static final Set<Action> BUILT_IN = new HashSet<>(
+      Arrays.asList(Actions.OK, Actions.CANCEL, Actions.CLOSE, Actions.YES, Actions.NO));
+
+  private final Stage stage = new Stage();
+  private final BorderPane root = new BorderPane();
+  private final HBox buttonBar = new HBox(10);
+  private final ObservableList<Action> actions = FXCollections.observableArrayList();
+  private Action selectedAction;
+
+  public Dialog(Window owner, String title, boolean lightweight, DialogStyle style) {
+    if (owner != null) {
+      stage.initOwner(owner);
+      stage.initModality(Modality.WINDOW_MODAL);
+    } else {
+      stage.initModality(Modality.APPLICATION_MODAL);
+    }
+    stage.setTitle(title);
+    buttonBar.setAlignment(Pos.CENTER_RIGHT);
+    buttonBar.setPadding(new Insets(10));
+    root.setBottom(buttonBar);
+    stage.setScene(new Scene(root));
+  }
+
+  public void setTitle(String title) {
+    stage.setTitle(title);
+  }
+
+  public void setMasthead(String masthead) {
+    if (masthead == null || masthead.isEmpty()) {
+      root.setTop(null);
+      return;
+    }
+    Label header = new Label(masthead);
+    header.setWrapText(true);
+    header.setPadding(new Insets(10));
+    root.setTop(header);
+  }
+
+  public void setContent(Node content) {
+    root.setCenter(content);
+  }
+
+  public ObservableList<Action> getActions() {
+    return actions;
+  }
+
+  /** The owning window; its scene exists from construction, so accelerators can be registered early. */
+  public Window getWindow() {
+    return stage;
+  }
+
+  /** Shows the dialog without blocking (built-in buttons close it; custom handlers manage their own flow). */
+  public void show() {
+    buildButtons();
+    stage.sizeToScene();
+    stage.show();
+  }
+
+  /** Shows the dialog modally and returns the action whose button was pressed (null if dismissed). */
+  public Action showAndWaitForAction() {
+    buildButtons();
+    selectedAction = null;
+    stage.sizeToScene();
+    stage.showAndWait();
+    return selectedAction;
+  }
+
+  public void hide() {
+    stage.close();
+  }
+
+  private void buildButtons() {
+    buttonBar.getChildren().clear();
+    for (Action action : actions) {
+      Button button = new Button();
+      button.textProperty().bind(action.textProperty());
+      button.graphicProperty().bind(action.graphicProperty());
+      button.disableProperty().bind(action.disabledProperty());
+      button.setOnAction(event -> {
+        action.handle(event);
+        if (BUILT_IN.contains(action)) {
+          selectedAction = action;
+          hide();
+        }
+      });
+      buttonBar.getChildren().add(button);
+    }
+  }
+}

--- a/Platform_FX/src/main/java/net/sf/anathema/framework/fx/compat/DialogStyle.java
+++ b/Platform_FX/src/main/java/net/sf/anathema/framework/fx/compat/DialogStyle.java
@@ -1,0 +1,10 @@
+package net.sf.anathema.framework.fx.compat;
+
+/**
+ * Compatibility replacement for {@code org.controlsfx.dialog.DialogStyle}, which was removed in
+ * ControlsFX 8.20+. Anathema only ever used {@link #NATIVE}; the value is now a no-op marker kept
+ * so existing call sites compile unchanged.
+ */
+public enum DialogStyle {
+  NATIVE, CROSS_PLATFORM, UNDECORATED
+}

--- a/Platform_FX/src/main/java/net/sf/anathema/framework/fx/compat/Dialogs.java
+++ b/Platform_FX/src/main/java/net/sf/anathema/framework/fx/compat/Dialogs.java
@@ -1,0 +1,87 @@
+package net.sf.anathema.framework.fx.compat;
+
+import javafx.scene.control.Label;
+import javafx.scene.control.TextArea;
+import javafx.stage.Window;
+import org.controlsfx.control.action.Action;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+
+/**
+ * Compatibility replacement for the {@code org.controlsfx.dialog.Dialogs} fluent builder removed after
+ * ControlsFX 8.0.x. Only the methods Anathema used are provided, backed by {@link Dialog}.
+ */
+public class Dialogs {
+
+  private Window owner;
+  private String title;
+  private String masthead;
+  private String message;
+  private Action[] actions;
+
+  public static Dialogs create() {
+    return new Dialogs();
+  }
+
+  public Dialogs owner(Window owner) {
+    this.owner = owner;
+    return this;
+  }
+
+  public Dialogs title(String title) {
+    this.title = title;
+    return this;
+  }
+
+  public Dialogs masthead(String masthead) {
+    this.masthead = masthead;
+    return this;
+  }
+
+  public Dialogs message(String message) {
+    this.message = message;
+    return this;
+  }
+
+  /** Visual style is a no-op on modern JavaFX; kept for source compatibility. */
+  public Dialogs style(DialogStyle style) {
+    return this;
+  }
+
+  public Dialogs actions(Action... actions) {
+    this.actions = actions;
+    return this;
+  }
+
+  /** Shows a modal confirmation and returns the {@link Action} whose button was pressed. */
+  public Action showConfirm() {
+    Dialog dialog = newDialog();
+    Label content = new Label(message);
+    content.setWrapText(true);
+    dialog.setContent(content);
+    dialog.getActions().setAll(actions != null ? actions : new Action[]{Dialog.Actions.OK});
+    return dialog.showAndWaitForAction();
+  }
+
+  /** Shows a modal error dialog with the throwable's stack trace in an expandable text area. */
+  public void showException(Throwable throwable) {
+    Dialog dialog = newDialog();
+    StringWriter writer = new StringWriter();
+    throwable.printStackTrace(new PrintWriter(writer));
+    TextArea details = new TextArea(writer.toString());
+    details.setEditable(false);
+    details.setWrapText(false);
+    details.setPrefColumnCount(60);
+    details.setPrefRowCount(20);
+    dialog.setContent(details);
+    dialog.getActions().setAll(Dialog.Actions.OK);
+    dialog.showAndWaitForAction();
+  }
+
+  private Dialog newDialog() {
+    Dialog dialog = new Dialog(owner, title, false, DialogStyle.NATIVE);
+    dialog.setMasthead(masthead);
+    return dialog;
+  }
+}

--- a/Platform_FX/src/main/java/net/sf/anathema/framework/presenter/action/about/AnathemaAboutAction.java
+++ b/Platform_FX/src/main/java/net/sf/anathema/framework/presenter/action/about/AnathemaAboutAction.java
@@ -13,8 +13,8 @@ import net.sf.anathema.platform.fx.Stylesheet;
 import net.sf.anathema.platform.markdown.HtmlConverter;
 import net.sf.anathema.platform.markdown.HtmlText;
 import net.sf.anathema.platform.markdown.WikiText;
+import net.sf.anathema.framework.fx.compat.Dialog;
 import org.apache.commons.io.IOUtils;
-import org.controlsfx.dialog.Dialog;
 import org.tbee.javafx.scene.layout.MigPane;
 
 import java.io.IOException;

--- a/Platform_FX/src/main/java/net/sf/anathema/framework/presenter/action/updatecheck/FxUpdateView.java
+++ b/Platform_FX/src/main/java/net/sf/anathema/framework/presenter/action/updatecheck/FxUpdateView.java
@@ -14,10 +14,10 @@ import net.sf.anathema.lib.gui.layout.LayoutUtils;
 import net.sf.anathema.platform.fx.FxTextView;
 import net.sf.anathema.platform.fx.FxThreading;
 import net.sf.anathema.platform.tool.FxButtonTool;
-import org.controlsfx.dialog.Dialog;
+import net.sf.anathema.framework.fx.compat.Dialog;
 import org.tbee.javafx.scene.layout.MigPane;
 
-import static org.controlsfx.dialog.Dialog.Actions.OK;
+import static net.sf.anathema.framework.fx.compat.Dialog.Actions.OK;
 
 public class FxUpdateView implements UpdateView {
 

--- a/Platform_FX/src/main/java/net/sf/anathema/framework/repository/tree/FxVetor.java
+++ b/Platform_FX/src/main/java/net/sf/anathema/framework/repository/tree/FxVetor.java
@@ -2,11 +2,11 @@ package net.sf.anathema.framework.repository.tree;
 
 import net.sf.anathema.interaction.Command;
 import net.sf.anathema.lib.gui.list.veto.Vetor;
+import net.sf.anathema.framework.fx.compat.Dialogs;
 import org.controlsfx.control.action.Action;
-import org.controlsfx.dialog.Dialogs;
 
-import static org.controlsfx.dialog.Dialog.Actions.NO;
-import static org.controlsfx.dialog.Dialog.Actions.YES;
+import static net.sf.anathema.framework.fx.compat.Dialog.Actions.NO;
+import static net.sf.anathema.framework.fx.compat.Dialog.Actions.YES;
 
 public class FxVetor implements Vetor {
   private String title;

--- a/Platform_FX/src/main/java/net/sf/anathema/framework/repository/tree/RepositoryViewAction.java
+++ b/Platform_FX/src/main/java/net/sf/anathema/framework/repository/tree/RepositoryViewAction.java
@@ -7,7 +7,7 @@ import net.sf.anathema.framework.environment.fx.UiEnvironment;
 import net.sf.anathema.framework.messaging.IMessaging;
 import net.sf.anathema.initialization.ItemTypeCollection;
 import net.sf.anathema.interaction.Command;
-import org.controlsfx.dialog.Dialog;
+import net.sf.anathema.framework.fx.compat.Dialog;
 
 public class RepositoryViewAction implements Command {
   private final IApplicationModel model;

--- a/Platform_FX/src/main/java/net/sf/anathema/platform/fx/dot/DotSelectionSpinnerSkin.java
+++ b/Platform_FX/src/main/java/net/sf/anathema/platform/fx/dot/DotSelectionSpinnerSkin.java
@@ -1,6 +1,6 @@
 package net.sf.anathema.platform.fx.dot;
 
-import com.sun.javafx.Utils;
+import com.sun.javafx.util.Utils;
 import javafx.beans.value.ChangeListener;
 import javafx.beans.value.ObservableValue;
 import javafx.collections.ObservableList;

--- a/packaging/macos/README.md
+++ b/packaging/macos/README.md
@@ -1,0 +1,101 @@
+# Anathema — macOS DMG installer (Apple Silicon)
+
+`build-dmg.sh` produces a **self-contained, double-click `.dmg`** for Anathema on Apple
+Silicon (arm64) Macs:
+
+```
+dist/Anathema-6.0.0-arm64.dmg
+```
+
+The DMG bundles its own Java 8 + JavaFX runtime, so end users do **not** need Java installed.
+Open the DMG, drag **Anathema** to **Applications**, done.
+
+## For end users — first launch (important)
+
+The DMG is **not** signed with an Apple Developer ID (this is a free, open-source build), so
+the first time you open it macOS Gatekeeper will warn that the developer "cannot be verified."
+This is expected. Either:
+
+- **Right-click** (or Control-click) `Anathema.app` in Applications → **Open** → **Open**; or
+- run once in Terminal:
+  ```sh
+  xattr -dr com.apple.quarantine /Applications/Anathema.app
+  ```
+
+After the first launch it opens normally with a double-click. Anathema stores its character
+data in `~/.anathema/repository` (configurable in the app's preferences).
+
+## For maintainers — building the DMG
+
+### One command
+```sh
+packaging/macos/build-dmg.sh
+```
+
+That's it. The first run downloads the pinned toolchain (~250 MB) into
+`~/.cache/anathema-dmg-toolchain`; later runs reuse it.
+
+### Requirements
+- An **Apple Silicon** Mac with **Rosetta 2** (`softwareupdate --install-rosetta`).
+- A **JDK 17+** installed somewhere (its `jpackage` builds the DMG). The script auto-detects
+  any JDK under `/Library/Java/JavaVirtualMachines`; override with `JPACKAGE=/path/to/jpackage`.
+- Internet access on first run (toolchain + Gradle dependency downloads).
+
+### What the script does, and why
+Anathema's own build is **Gradle 2.2.1 (2014)** and only runs on **JDK 8**, and the original
+macOS release pipeline (Oracle AppBundler + an Oracle JRE download that no longer exists) is
+dead. So the script:
+
+1. **Builds the jars** with a JavaFX-bundled **Zulu 8 JDK (x64)** run **under Rosetta 2** —
+   Gradle 2.2.1 ships no arm64 native libraries. Only the jar-producing tasks are run
+   (`:Anathema:jar copyExternalDependencies copyAnathemaModules`); the broken Win/Mac/Linux
+   release tasks are skipped. The jars are architecture-independent.
+   - JavaFX is required by several modules (e.g. `Platform_FX`) and is **absent from Temurin
+     8**, which is why a Zulu "FX" build is used.
+2. **Stages** the main jar + all dependency/plugin jars into `build/jpackage-input/` and adds
+   a `Class-Path` manifest to `anathema.jar` so the JVM loads every sibling jar.
+3. **Packages** with `jpackage --type dmg`, bundling a JavaFX-bundled **Zulu 8 JRE (arm64)**
+   as the runtime and `Development_Distribution/Mac/sungear.icns` as the icon. `jpackage`
+   ad-hoc signs the `.app` (required for arm64 to launch); the DMG stays unsigned.
+
+### Configuration (environment overrides)
+| Variable | Default | Purpose |
+|---|---|---|
+| `APP_VERSION` | from `gradle.properties` | Version in the app/DMG |
+| `DEST` | `dist/` | Output directory |
+| `JPACKAGE` | auto-detected | Path to a JDK 17+ `jpackage` |
+| `BUILD_JDK_HOME` | Zulu 8 FX x64 (auto-downloaded) | JDK used to compile (under Rosetta) |
+| `BUNDLE_JRE_HOME` | Zulu 8 FX arm64 (auto-downloaded) | Runtime bundled into the app |
+| `ANATHEMA_TOOLCHAIN` | `~/.cache/anathema-dmg-toolchain` | Toolchain download cache |
+
+## Source compatibility changes
+
+Anathema was written against the 2014-era JavaFX 8 it shipped (Oracle JRE `1.8.0_05`). Running
+on a current, redistributable OpenJFX 8 (Azul Zulu) required these source changes:
+
+1. **Internal JavaFX API rename.** `com.sun.javafx.Utils` moved to `com.sun.javafx.util.Utils`:
+   - `Platform_FX/.../dot/DotSelectionSpinnerSkin.java` import updated.
+
+2. **ControlsFX upgrade 8.0.6 → 8.40.18.** ControlsFX 8.0.6 calls early-JavaFX-8 internal APIs
+   that modern OpenJFX 8 removed (notably `com.sun.javafx.scene.traversal.TraversalEngine(Parent,
+   boolean)`), so it cannot run on any maintained JavaFX. Upgrading to the last JavaFX-8 release
+   (8.40.18) fixes this but removes `org.controlsfx.dialog.Dialog`/`Dialogs` and
+   `org.controlsfx.control.action.AbstractAction`. To keep the upgrade minimal:
+   - A tiny compat layer reproduces the slice of the old dialog API the app used, backed by plain
+     JavaFX: `Platform_FX/.../framework/fx/compat/{Dialog,Dialogs,DialogStyle}.java`.
+   - The 9 dialog files switched their `org.controlsfx.dialog.*` imports to that compat package.
+   - `AbstractAction` subclasses became `org.controlsfx.control.action.Action` (which is still
+     present): `ConfigurableControlsFxAction` and `FxEditStatsDialog`.
+   - `NotificationPane` is unchanged between the two ControlsFX versions.
+
+3. **Default repository location.** The default was the *relative* path `./repository/`, which a
+   Finder-launched `.app` (working directory `/`) cannot create. Changed to the per-user
+   `%USER_HOME%/.anathema/repository/` (the `%USER_HOME%` token is already expanded by
+   `RepositoryLocationResolver`): `Platform/.../repository/preferences/RepositoryPreferenceModel.java`.
+
+## Notes & limitations
+- **Apple Silicon only.** For Intel Macs, build with the x64 Zulu FX JRE as `BUNDLE_JRE_HOME`
+  and run `jpackage` from an x64 JDK; or produce both and ship two DMGs.
+- **Unsigned / not notarized.** Requires the one-time Gatekeeper step above. For a true
+  one-click experience, sign & notarize with an Apple Developer ID and add
+  `--mac-sign --mac-signing-key-user-name "Developer ID Application: …"` plus `notarytool`.

--- a/packaging/macos/_set_classpath.py
+++ b/packaging/macos/_set_classpath.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+"""Add a Class-Path manifest attribute to a jar, listing every *other* jar in its directory.
+
+jpackage launches Anathema via its main jar; the JVM pulls in the sibling dependency/plugin
+jars through this Class-Path attribute. JAR manifests cap every physical line at 72 bytes, so
+the (long) Class-Path value is wrapped with continuation lines per the manifest spec — the
+JDK 8 jar tool refuses to even read an over-long line, so we write the wrapped manifest here.
+
+Usage: _set_classpath.py <path-to-main-jar>
+"""
+import os
+import shutil
+import sys
+import zipfile
+
+MANIFEST = "META-INF/MANIFEST.MF"
+
+
+def wrap72(logical_line: str) -> bytes:
+    """Wrap a logical manifest line into <=72-byte physical lines (continuation = leading space)."""
+    b = logical_line.encode("utf-8")
+    out = bytearray(b[:72])
+    b = b[72:]
+    while b:
+        out += b"\r\n " + b[:71]  # leading space counts toward the 72-byte limit
+        b = b[71:]
+    out += b"\r\n"
+    return bytes(out)
+
+
+def main() -> None:
+    jar_path = sys.argv[1]
+    input_dir = os.path.dirname(os.path.abspath(jar_path))
+    main_jar = os.path.basename(jar_path)
+
+    names = sorted(
+        f for f in os.listdir(input_dir) if f.endswith(".jar") and f != main_jar
+    )
+    cp_logical = "Class-Path: " + " ".join(names)
+
+    with zipfile.ZipFile(jar_path, "r") as z:
+        existing = z.read(MANIFEST).decode("utf-8")
+        others = [(i, z.read(i.filename)) for i in z.infolist() if i.filename != MANIFEST]
+
+    # Keep existing main attributes, drop any prior Class-Path (and its continuation lines).
+    kept, in_classpath = [], False
+    for line in existing.split("\n"):
+        raw = line.rstrip("\r")
+        if raw.startswith(" "):
+            if in_classpath:
+                continue
+            kept.append(raw)
+            continue
+        in_classpath = raw.lower().startswith("class-path:")
+        if in_classpath or raw == "":
+            continue
+        kept.append(raw)
+
+    manifest_bytes = (
+        ("\r\n".join(kept)).encode("utf-8") + b"\r\n" + wrap72(cp_logical) + b"\r\n"
+    )
+
+    tmp = jar_path + ".tmp"
+    with zipfile.ZipFile(tmp, "w", zipfile.ZIP_DEFLATED) as z:
+        z.writestr(zipfile.ZipInfo(MANIFEST), manifest_bytes)
+        for info, data in others:
+            z.writestr(info, data)
+    shutil.move(tmp, jar_path)
+    print(f"Class-Path set: {len(names)} jars")
+
+
+if __name__ == "__main__":
+    main()

--- a/packaging/macos/build-dmg.sh
+++ b/packaging/macos/build-dmg.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+#
+# build-dmg.sh — Build a self-contained, double-click macOS .dmg installer for Anathema.
+#
+# Produces:  dist/Anathema-<version>-arm64.dmg   (Apple Silicon, bundled Java 8 + JavaFX runtime)
+#
+# The DMG is UNSIGNED (no Apple Developer ID). The app itself is ad-hoc signed by jpackage so
+# it launches on Apple Silicon; end users clear the download quarantine once — see README.md.
+#
+# Why this is not just "gradlew build":
+#   * Anathema's build is Gradle 2.2.1 (2014) and only runs on JDK 8.
+#   * On Apple Silicon, Gradle 2.2.1 has no native libs, so the build runs under an Intel
+#     JDK 8 via Rosetta 2. The resulting jars are architecture-independent.
+#   * Several modules (Platform_FX, ...) require JavaFX, which is absent from Temurin 8, so we
+#     build with a JavaFX-bundled Zulu 8 JDK and ship a JavaFX-bundled Zulu 8 arm64 JRE.
+#   * The original release pipeline (AppBundler + Oracle JRE download) is dead; we use jpackage.
+#
+# All three toolchain components are auto-downloaded into ~/.cache/anathema-dmg-toolchain if
+# absent. Override any path via the env vars below.
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Configuration (override via environment)
+# ---------------------------------------------------------------------------
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+APP_NAME="Anathema"
+MAIN_CLASS="net.sf.anathema.AnathemaBootLoader"
+MAIN_JAR="anathema.jar"
+IDENTIFIER="net.sf.anathema"
+ICON="$REPO_ROOT/Development_Distribution/Mac/sungear.icns"
+DEST="${DEST:-$REPO_ROOT/dist}"
+
+# Version: read from gradle.properties unless APP_VERSION is set.
+if [[ -z "${APP_VERSION:-}" ]]; then
+  vmaj=$(awk -F= '/^version_major/{gsub(/[ \r]/,"",$2);print $2}' "$REPO_ROOT/gradle.properties")
+  vmin=$(awk -F= '/^version_minor/{gsub(/[ \r]/,"",$2);print $2}' "$REPO_ROOT/gradle.properties")
+  vrev=$(awk -F= '/^version_revision/{gsub(/[ \r]/,"",$2);print $2}' "$REPO_ROOT/gradle.properties")
+  APP_VERSION="${vmaj:-6}.${vmin:-0}.${vrev:-0}"
+fi
+
+TC="${ANATHEMA_TOOLCHAIN:-$HOME/.cache/anathema-dmg-toolchain}"
+
+# JavaFX-bundled Zulu 8 (pinned). Build JDK is x64 (runs under Rosetta for Gradle 2.2.1);
+# the bundled runtime is the arm64 JRE that ships inside the app.
+BUILD_JDK_URL="https://cdn.azul.com/zulu/bin/zulu8.94.0.17-ca-fx-jdk8.0.492-macosx_x64.tar.gz"
+BUNDLE_JRE_URL="https://cdn.azul.com/zulu/bin/zulu8.94.0.17-ca-fx-jre8.0.492-macosx_aarch64.tar.gz"
+BUILD_JDK_HOME="${BUILD_JDK_HOME:-$TC/zulufx8-jdk-x64/zulu8.94.0.17-ca-fx-jdk8.0.492-macosx_x64/Contents/Home}"
+BUNDLE_JRE_HOME="${BUNDLE_JRE_HOME:-$TC/zulufx8-jre/zulu8.94.0.17-ca-fx-jre8.0.492-macosx_aarch64/Contents/Home}"
+
+log() { printf '\033[1;36m==>\033[0m %s\n' "$*"; }
+die() { printf '\033[1;31mERROR:\033[0m %s\n' "$*" >&2; exit 1; }
+
+# ---------------------------------------------------------------------------
+# Toolchain
+# ---------------------------------------------------------------------------
+fetch_runtime() { # url, dest_parent_dir, expected_home
+  local url="$1" dest="$2" home="$3"
+  [[ -x "$home/bin/java" ]] && return 0
+  log "Downloading $(basename "$url") ..."
+  mkdir -p "$dest"
+  local tgz="$dest/$(basename "$url")"
+  curl -fsSL -o "$tgz" "$url"
+  tar xzf "$tgz" -C "$dest"
+  [[ -x "$home/bin/java" ]] || die "Runtime not found at $home after extraction"
+}
+
+find_jpackage() {
+  if [[ -n "${JPACKAGE:-}" ]]; then echo "$JPACKAGE"; return; fi
+  # Prefer the highest-versioned installed JDK that ships jpackage (JDK 14+).
+  local home
+  for home in $(ls -d /Library/Java/JavaVirtualMachines/*/Contents/Home 2>/dev/null | sort -rV); do
+    if [[ -x "$home/bin/jpackage" ]]; then echo "$home/bin/jpackage"; return; fi
+  done
+  local jp="$(/usr/libexec/java_home 2>/dev/null)/bin/jpackage"
+  [[ -x "$jp" ]] && { echo "$jp"; return; }
+  die "jpackage not found. Install a JDK 17+ (e.g. 'brew install --cask temurin') or set JPACKAGE=..."
+}
+
+# ---------------------------------------------------------------------------
+# Build
+# ---------------------------------------------------------------------------
+log "Anathema $APP_VERSION  →  $DEST/$APP_NAME-$APP_VERSION-arm64.dmg"
+[[ -f "$ICON" ]] || die "Icon not found: $ICON"
+
+fetch_runtime "$BUILD_JDK_URL"  "$TC/zulufx8-jdk-x64" "$BUILD_JDK_HOME"
+fetch_runtime "$BUNDLE_JRE_URL" "$TC/zulufx8-jre"     "$BUNDLE_JRE_HOME"
+JPACKAGE="$(find_jpackage)"
+log "Build JDK : $BUILD_JDK_HOME"
+log "Bundle JRE: $BUNDLE_JRE_HOME"
+log "jpackage  : $JPACKAGE"
+
+log "Building application jars with Gradle (Intel JDK 8 under Rosetta) ..."
+cd "$REPO_ROOT"
+chmod +x ./gradlew
+JAVA_HOME="$BUILD_JDK_HOME" arch -x86_64 ./gradlew --no-daemon clean \
+  :Anathema:jar copyExternalDependencies copyAnathemaModules
+
+[[ -f "Anathema/build/libs/$MAIN_JAR" ]] || die "Main jar not built: Anathema/build/libs/$MAIN_JAR"
+
+# ---------------------------------------------------------------------------
+# Stage jars into a single input directory and wire up the classpath
+# ---------------------------------------------------------------------------
+INPUT="$REPO_ROOT/build/jpackage-input"
+log "Staging jars into $INPUT ..."
+rm -rf "$INPUT"; mkdir -p "$INPUT"
+cp "Anathema/build/libs/$MAIN_JAR" "$INPUT/"
+[[ -d build/dependencies ]] && cp build/dependencies/*.jar "$INPUT/" 2>/dev/null || true
+[[ -d build/plugins ]]      && cp build/plugins/*.jar      "$INPUT/" 2>/dev/null || true
+log "Staged $(ls "$INPUT"/*.jar | wc -l | tr -d ' ') jars."
+
+# jpackage launches the app via the main jar; sibling jars are pulled in through the main
+# jar's Class-Path manifest attribute (written with correct 72-byte line wrapping).
+log "Writing Class-Path manifest into $MAIN_JAR ..."
+python3 "$SCRIPT_DIR/_set_classpath.py" "$INPUT/$MAIN_JAR"
+
+# ---------------------------------------------------------------------------
+# Build the DMG with jpackage
+# ---------------------------------------------------------------------------
+log "Running jpackage ..."
+rm -rf "$DEST"; mkdir -p "$DEST"
+"$JPACKAGE" \
+  --type dmg \
+  --name "$APP_NAME" \
+  --app-version "$APP_VERSION" \
+  --input "$INPUT" \
+  --main-jar "$MAIN_JAR" \
+  --main-class "$MAIN_CLASS" \
+  --runtime-image "$BUNDLE_JRE_HOME" \
+  --icon "$ICON" \
+  --mac-package-identifier "$IDENTIFIER" \
+  --java-options "-Dapple.laf.useScreenMenuBar=true" \
+  --dest "$DEST"
+
+# jpackage names the file "<App>-<version>.dmg"; add an arch suffix for clarity.
+SRC_DMG="$DEST/$APP_NAME-$APP_VERSION.dmg"
+OUT_DMG="$DEST/$APP_NAME-$APP_VERSION-arm64.dmg"
+[[ -f "$SRC_DMG" ]] && mv -f "$SRC_DMG" "$OUT_DMG"
+
+log "Done: $OUT_DMG"
+ls -lh "$OUT_DMG"


### PR DESCRIPTION
## What & why

Adds a **one-command, self-contained macOS (Apple Silicon) `.dmg` installer** so an end user can install Anathema with a double-click — no Java required (the runtime is bundled). Getting it to actually *launch* also required fixing a few places where the app depended on a 2014-era JavaFX 8 (it originally shipped Oracle JRE `1.8.0_05`) that no current, redistributable OpenJFX 8 provides.

The original `gradlew` Mac release task is dead (it relied on the now-unavailable `oracle:jre-mac64` download and the deprecated Oracle AppBundler), so packaging is done with `jpackage` instead.

## Packaging (`packaging/macos/`)
- **`build-dmg.sh`** — builds the jars with a JavaFX-bundled **Zulu 8 JDK** run under **Rosetta 2** (Gradle 2.2.1 ships no arm64 native libs; the jars are arch-independent), stages all jars, and runs **`jpackage`** to emit a self-contained **arm64 `.dmg`** with a bundled **Zulu 8 (JavaFX) runtime**. Auto-downloads the pinned toolchain into `~/.cache`.
- **`_set_classpath.py`** — writes a correctly 72-byte-wrapped `Class-Path` manifest into the main jar so jpackage's launcher loads every dependency/plugin jar.
- **`README.md`** — build prerequisites and the end-user Gatekeeper note (the DMG is unsigned/not notarized, so first launch needs right-click → Open).

## App compatibility fixes
- **ControlsFX `8.0.6` → `8.40.18`.** 8.0.6 calls early-JavaFX-8 internals removed from modern OpenJFX 8 (e.g. `com.sun.javafx.scene.traversal.TraversalEngine(Parent, boolean)`), so it crashes at runtime on any maintained JavaFX. 8.40.18 removes the old `org.controlsfx.dialog.Dialog`/`Dialogs` API and `AbstractAction`, so:
  - a small **JavaFX-backed compat layer** (`framework/fx/compat/{Dialog,Dialogs,DialogStyle}`) reproduces the slice of the old dialog API the app used; the 9 dialog files switched their imports to it;
  - `AbstractAction` subclasses now extend `org.controlsfx.control.action.Action`.
- **Internal JavaFX rename:** `com.sun.javafx.Utils` → `com.sun.javafx.util.Utils`.
- **Default repository location** → `%USER_HOME%/.anathema/repository` (the `%USER_HOME%` token is already expanded by `RepositoryLocationResolver`). The previous relative `./repository/` fails for a Finder-launched `.app`, whose working directory is `/` and is read-only.
- **logback `FILE` appender** → `${user.home}/.anathema/runtime.log` (same read-only-cwd problem).

## Reviewer notes
- **Apple Silicon only** for now; an Intel/universal build needs an x64 Zulu FX runtime + x64 `jpackage` (or two DMGs).
- The DMG is **unsigned/not notarized** (no Apple Developer ID); the README documents the one-time Gatekeeper workaround.
- The ControlsFX upgrade is the largest change. `NotificationPane` is unchanged between the two versions; only `Dialog`/`Dialogs`/`AbstractAction` needed porting.
- Verified end-to-end: built the DMG, installed it, and launched from a Finder-equivalent working directory (`cwd=/`) — the app boots cleanly, creates `~/.anathema/repository`, logs to `~/.anathema/runtime.log`, and runs with no errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)